### PR TITLE
Update responsive_drawer.gleam

### DIFF
--- a/src/docs/components/responsive_drawer.gleam
+++ b/src/docs/components/responsive_drawer.gleam
@@ -78,7 +78,7 @@ pub fn responsive_drawer(ctx: Context, props) {
                   False -> Some("hidden")
                 },
                 Some(
-                  "sm:block w-64 z-40 transition-transform -translate-x-full translate-x-0 transition-transform",
+                  "md:block w-64 z-40 transition-transform -translate-x-full translate-x-0 transition-transform",
                 ),
               ]),
             ],
@@ -94,7 +94,7 @@ pub fn responsive_drawer(ctx: Context, props) {
             ],
           ),
           div(
-            [class("relative flex-1")],
+            [class("relative flex-1 overflow-hidden")],
             [
               button(
                 [


### PR DESCRIPTION
This fixes overflowing on smaller screens
The md:block makes the aside collapsed for a bit longer
The overflow-hidden forces elements respect the drawers authoriteh over available space :D