### PR TITLE
Replace handler hook with element_id based approach

### DIFF
--- a/src/sprocket.gleam
+++ b/src/sprocket.gleam
@@ -56,7 +56,7 @@ pub fn new(
 
 type Payload {
   JoinPayload(csrf_token: String, initial_props: Option(Dict(String, String)))
-  EventPayload(kind: String, id: String, payload: Dynamic)
+  EventPayload(element_id: String, kind: String, payload: Dynamic)
   HookEventPayload(id: String, event: String, payload: Option(Dynamic))
   EmptyPayload(nothing: Option(String))
 }
@@ -99,12 +99,12 @@ pub fn handle_ws(spkt: Sprocket(p), msg: String) -> Result(Response(p), String) 
         }
       }
     }
-    Ok(#("event", EventPayload(kind, event_id, payload))) -> {
-      logger.debug("Event: " <> kind <> " " <> event_id)
+    Ok(#("event", EventPayload(element_id, kind, payload))) -> {
+      logger.debug("Event: element " <> element_id <> " " <> kind)
 
       use runtime <- require_runtime(spkt)
 
-      runtime.process_event(runtime, event_id, payload)
+      runtime.process_event(runtime, element_id, kind, payload)
 
       Ok(Empty)
     }
@@ -210,8 +210,8 @@ fn decode_event(data: Dynamic) {
     dynamic.string,
     dynamic.decode3(
       EventPayload,
-      field("kind", dynamic.string),
       field("id", dynamic.string),
+      field("kind", dynamic.string),
       field("payload", dynamic.dynamic),
     ),
   )

--- a/src/sprocket/hooks.gleam
+++ b/src/sprocket/hooks.gleam
@@ -4,9 +4,8 @@ import gleam/option.{type Option, None, Some}
 import gleam/result
 import sprocket/context.{
   type Attribute, type ClientDispatcher, type ClientEventHandler, type Context,
-  type EffectCleanup, type Element, type HandlerFn, type HookDependencies,
-  type HookId, type IdentifiableHandler, Callback, CallbackResult, Changed,
-  Client, ClientHook, Context, Effect, Handler, IdentifiableHandler, Unchanged,
+  type EffectCleanup, type Element, type HookDependencies, type HookId, Callback,
+  CallbackResult, Changed, Client, ClientHook, Context, Effect, Unchanged,
   compare_deps,
 }
 import sprocket/internal/exceptions.{throw_on_unexpected_hook_result}
@@ -134,26 +133,6 @@ pub fn effect(
   let ctx = context.update_hook(ctx, Effect(id, effect_fn, deps, prev), index)
 
   cb(ctx)
-}
-
-/// Handler Hook
-/// -------------
-/// Creates a handler callback that can be triggered from DOM event attributes. The callback
-/// function will be called with the event payload. This hook ensures that the handler
-/// identifier remains stable preventing unnecessary id changes across renders.
-pub fn handler(
-  ctx: Context,
-  handler_fn: HandlerFn,
-  cb: fn(Context, IdentifiableHandler) -> #(ctx, Element),
-) -> #(ctx, Element) {
-  let assert #(ctx, Handler(id, _handler_fn), index) =
-    context.fetch_or_init_hook(ctx, fn() {
-      Handler(unique.cuid(ctx.cuid_channel), handler_fn)
-    })
-
-  let ctx = context.update_hook(ctx, Handler(id, handler_fn), index)
-
-  cb(ctx, IdentifiableHandler(id, handler_fn))
 }
 
 /// Memo Hook

--- a/src/sprocket/html/events.gleam
+++ b/src/sprocket/html/events.gleam
@@ -4,139 +4,139 @@ import sprocket/context.{type Attribute, Attribute, Event}
 
 // Events
 
-type Handler =
+type EventCallback =
   fn(Dynamic) -> Nil
 
-pub fn event(name: String, handler: Handler) -> Attribute {
-  Event(name, handler)
+pub fn event(name: String, cb: EventCallback) -> Attribute {
+  Event(name, cb)
 }
 
-pub fn on_blur(handler: Handler) -> Attribute {
-  event("blur", handler)
+pub fn on_blur(cb: EventCallback) -> Attribute {
+  event("blur", cb)
 }
 
-pub fn on_change(handler: Handler) -> Attribute {
-  event("change", handler)
+pub fn on_change(cb: EventCallback) -> Attribute {
+  event("change", cb)
 }
 
-pub fn on_check(handler: Handler) -> Attribute {
-  event("check", handler)
+pub fn on_check(cb: EventCallback) -> Attribute {
+  event("check", cb)
 }
 
-pub fn on_click(handler: Handler) -> Attribute {
-  event("click", handler)
+pub fn on_click(cb: EventCallback) -> Attribute {
+  event("click", cb)
 }
 
-pub fn on_dblclick(handler: Handler) -> Attribute {
-  event("dblclick", handler)
+pub fn on_dblclick(cb: EventCallback) -> Attribute {
+  event("dblclick", cb)
 }
 
-pub fn on_drag(handler: Handler) -> Attribute {
-  event("drag", handler)
+pub fn on_drag(cb: EventCallback) -> Attribute {
+  event("drag", cb)
 }
 
-pub fn on_dragend(handler: Handler) -> Attribute {
-  event("dragend", handler)
+pub fn on_dragend(cb: EventCallback) -> Attribute {
+  event("dragend", cb)
 }
 
-pub fn on_dragenter(handler: Handler) -> Attribute {
-  event("dragenter", handler)
+pub fn on_dragenter(cb: EventCallback) -> Attribute {
+  event("dragenter", cb)
 }
 
-pub fn on_dragleave(handler: Handler) -> Attribute {
-  event("dragleave", handler)
+pub fn on_dragleave(cb: EventCallback) -> Attribute {
+  event("dragleave", cb)
 }
 
-pub fn on_dragover(handler: Handler) -> Attribute {
-  event("dragover", handler)
+pub fn on_dragover(cb: EventCallback) -> Attribute {
+  event("dragover", cb)
 }
 
-pub fn on_dragstart(handler: Handler) -> Attribute {
-  event("dragstart", handler)
+pub fn on_dragstart(cb: EventCallback) -> Attribute {
+  event("dragstart", cb)
 }
 
-pub fn on_drop(handler: Handler) -> Attribute {
-  event("drop", handler)
+pub fn on_drop(cb: EventCallback) -> Attribute {
+  event("drop", cb)
 }
 
-pub fn on_focus(handler: Handler) -> Attribute {
-  event("focus", handler)
+pub fn on_focus(cb: EventCallback) -> Attribute {
+  event("focus", cb)
 }
 
-pub fn on_focusin(handler: Handler) -> Attribute {
-  event("focusin", handler)
+pub fn on_focusin(cb: EventCallback) -> Attribute {
+  event("focusin", cb)
 }
 
-pub fn on_focusout(handler: Handler) -> Attribute {
-  event("focusout", handler)
+pub fn on_focusout(cb: EventCallback) -> Attribute {
+  event("focusout", cb)
 }
 
-pub fn on_input(handler: Handler) -> Attribute {
-  event("input", handler)
+pub fn on_input(cb: EventCallback) -> Attribute {
+  event("input", cb)
 }
 
-pub fn on_keydown(handler: Handler) -> Attribute {
-  event("keydown", handler)
+pub fn on_keydown(cb: EventCallback) -> Attribute {
+  event("keydown", cb)
 }
 
-pub fn on_keyup(handler: Handler) -> Attribute {
-  event("keyup", handler)
+pub fn on_keyup(cb: EventCallback) -> Attribute {
+  event("keyup", cb)
 }
 
-pub fn on_mousedown(handler: Handler) -> Attribute {
-  event("mousedown", handler)
+pub fn on_mousedown(cb: EventCallback) -> Attribute {
+  event("mousedown", cb)
 }
 
-pub fn on_mouseenter(handler: Handler) -> Attribute {
-  event("mouseenter", handler)
+pub fn on_mouseenter(cb: EventCallback) -> Attribute {
+  event("mouseenter", cb)
 }
 
-pub fn on_mouseleave(handler: Handler) -> Attribute {
-  event("mouseleave", handler)
+pub fn on_mouseleave(cb: EventCallback) -> Attribute {
+  event("mouseleave", cb)
 }
 
-pub fn on_mousemove(handler: Handler) -> Attribute {
-  event("mousemove", handler)
+pub fn on_mousemove(cb: EventCallback) -> Attribute {
+  event("mousemove", cb)
 }
 
-pub fn on_mouseout(handler: Handler) -> Attribute {
-  event("mouseout", handler)
+pub fn on_mouseout(cb: EventCallback) -> Attribute {
+  event("mouseout", cb)
 }
 
-pub fn on_mouseover(handler: Handler) -> Attribute {
-  event("mouseover", handler)
+pub fn on_mouseover(cb: EventCallback) -> Attribute {
+  event("mouseover", cb)
 }
 
-pub fn on_mouseup(handler: Handler) -> Attribute {
-  event("mouseup", handler)
+pub fn on_mouseup(cb: EventCallback) -> Attribute {
+  event("mouseup", cb)
 }
 
-pub fn on_scroll(handler: Handler) -> Attribute {
-  event("scroll", handler)
+pub fn on_scroll(cb: EventCallback) -> Attribute {
+  event("scroll", cb)
 }
 
-pub fn on_submit(handler: Handler) -> Attribute {
-  event("submit", handler)
+pub fn on_submit(cb: EventCallback) -> Attribute {
+  event("submit", cb)
 }
 
-pub fn on_touchcancel(handler: Handler) -> Attribute {
-  event("touchcancel", handler)
+pub fn on_touchcancel(cb: EventCallback) -> Attribute {
+  event("touchcancel", cb)
 }
 
-pub fn on_touchend(handler: Handler) -> Attribute {
-  event("touchend", handler)
+pub fn on_touchend(cb: EventCallback) -> Attribute {
+  event("touchend", cb)
 }
 
-pub fn on_touchmove(handler: Handler) -> Attribute {
-  event("touchmove", handler)
+pub fn on_touchmove(cb: EventCallback) -> Attribute {
+  event("touchmove", cb)
 }
 
-pub fn on_touchstart(handler: Handler) -> Attribute {
-  event("touchstart", handler)
+pub fn on_touchstart(cb: EventCallback) -> Attribute {
+  event("touchstart", cb)
 }
 
-pub fn on_wheel(handler: Handler) -> Attribute {
-  event("wheel", handler)
+pub fn on_wheel(cb: EventCallback) -> Attribute {
+  event("wheel", cb)
 }
 
 // Decoders used to extract values from events

--- a/src/sprocket/html/events.gleam
+++ b/src/sprocket/html/events.gleam
@@ -1,140 +1,141 @@
 import gleam/dict.{type Dict}
 import gleam/dynamic.{type DecodeError, type Dynamic}
-import sprocket/context.{
-  type Attribute, type IdentifiableHandler, Attribute, Event,
-}
+import sprocket/context.{type Attribute, Attribute, Event}
 
 // Events
 
-pub fn event(name: String, handler: IdentifiableHandler) -> Attribute {
+type Handler =
+  fn(Dynamic) -> Nil
+
+pub fn event(name: String, handler: Handler) -> Attribute {
   Event(name, handler)
 }
 
-pub fn on_blur(handler: IdentifiableHandler) -> Attribute {
+pub fn on_blur(handler: Handler) -> Attribute {
   event("blur", handler)
 }
 
-pub fn on_change(handler: IdentifiableHandler) -> Attribute {
+pub fn on_change(handler: Handler) -> Attribute {
   event("change", handler)
 }
 
-pub fn on_check(handler: IdentifiableHandler) -> Attribute {
+pub fn on_check(handler: Handler) -> Attribute {
   event("check", handler)
 }
 
-pub fn on_click(handler: IdentifiableHandler) -> Attribute {
+pub fn on_click(handler: Handler) -> Attribute {
   event("click", handler)
 }
 
-pub fn on_dblclick(handler: IdentifiableHandler) -> Attribute {
+pub fn on_dblclick(handler: Handler) -> Attribute {
   event("dblclick", handler)
 }
 
-pub fn on_drag(handler: IdentifiableHandler) -> Attribute {
+pub fn on_drag(handler: Handler) -> Attribute {
   event("drag", handler)
 }
 
-pub fn on_dragend(handler: IdentifiableHandler) -> Attribute {
+pub fn on_dragend(handler: Handler) -> Attribute {
   event("dragend", handler)
 }
 
-pub fn on_dragenter(handler: IdentifiableHandler) -> Attribute {
+pub fn on_dragenter(handler: Handler) -> Attribute {
   event("dragenter", handler)
 }
 
-pub fn on_dragleave(handler: IdentifiableHandler) -> Attribute {
+pub fn on_dragleave(handler: Handler) -> Attribute {
   event("dragleave", handler)
 }
 
-pub fn on_dragover(handler: IdentifiableHandler) -> Attribute {
+pub fn on_dragover(handler: Handler) -> Attribute {
   event("dragover", handler)
 }
 
-pub fn on_dragstart(handler: IdentifiableHandler) -> Attribute {
+pub fn on_dragstart(handler: Handler) -> Attribute {
   event("dragstart", handler)
 }
 
-pub fn on_drop(handler: IdentifiableHandler) -> Attribute {
+pub fn on_drop(handler: Handler) -> Attribute {
   event("drop", handler)
 }
 
-pub fn on_focus(handler: IdentifiableHandler) -> Attribute {
+pub fn on_focus(handler: Handler) -> Attribute {
   event("focus", handler)
 }
 
-pub fn on_focusin(handler: IdentifiableHandler) -> Attribute {
+pub fn on_focusin(handler: Handler) -> Attribute {
   event("focusin", handler)
 }
 
-pub fn on_focusout(handler: IdentifiableHandler) -> Attribute {
+pub fn on_focusout(handler: Handler) -> Attribute {
   event("focusout", handler)
 }
 
-pub fn on_input(handler: IdentifiableHandler) -> Attribute {
+pub fn on_input(handler: Handler) -> Attribute {
   event("input", handler)
 }
 
-pub fn on_keydown(handler: IdentifiableHandler) -> Attribute {
+pub fn on_keydown(handler: Handler) -> Attribute {
   event("keydown", handler)
 }
 
-pub fn on_keyup(handler: IdentifiableHandler) -> Attribute {
+pub fn on_keyup(handler: Handler) -> Attribute {
   event("keyup", handler)
 }
 
-pub fn on_mousedown(handler: IdentifiableHandler) -> Attribute {
+pub fn on_mousedown(handler: Handler) -> Attribute {
   event("mousedown", handler)
 }
 
-pub fn on_mouseenter(handler: IdentifiableHandler) -> Attribute {
+pub fn on_mouseenter(handler: Handler) -> Attribute {
   event("mouseenter", handler)
 }
 
-pub fn on_mouseleave(handler: IdentifiableHandler) -> Attribute {
+pub fn on_mouseleave(handler: Handler) -> Attribute {
   event("mouseleave", handler)
 }
 
-pub fn on_mousemove(handler: IdentifiableHandler) -> Attribute {
+pub fn on_mousemove(handler: Handler) -> Attribute {
   event("mousemove", handler)
 }
 
-pub fn on_mouseout(handler: IdentifiableHandler) -> Attribute {
+pub fn on_mouseout(handler: Handler) -> Attribute {
   event("mouseout", handler)
 }
 
-pub fn on_mouseover(handler: IdentifiableHandler) -> Attribute {
+pub fn on_mouseover(handler: Handler) -> Attribute {
   event("mouseover", handler)
 }
 
-pub fn on_mouseup(handler: IdentifiableHandler) -> Attribute {
+pub fn on_mouseup(handler: Handler) -> Attribute {
   event("mouseup", handler)
 }
 
-pub fn on_scroll(handler: IdentifiableHandler) -> Attribute {
+pub fn on_scroll(handler: Handler) -> Attribute {
   event("scroll", handler)
 }
 
-pub fn on_submit(handler: IdentifiableHandler) -> Attribute {
+pub fn on_submit(handler: Handler) -> Attribute {
   event("submit", handler)
 }
 
-pub fn on_touchcancel(handler: IdentifiableHandler) -> Attribute {
+pub fn on_touchcancel(handler: Handler) -> Attribute {
   event("touchcancel", handler)
 }
 
-pub fn on_touchend(handler: IdentifiableHandler) -> Attribute {
+pub fn on_touchend(handler: Handler) -> Attribute {
   event("touchend", handler)
 }
 
-pub fn on_touchmove(handler: IdentifiableHandler) -> Attribute {
+pub fn on_touchmove(handler: Handler) -> Attribute {
   event("touchmove", handler)
 }
 
-pub fn on_touchstart(handler: IdentifiableHandler) -> Attribute {
+pub fn on_touchstart(handler: Handler) -> Attribute {
   event("touchstart", handler)
 }
 
-pub fn on_wheel(handler: IdentifiableHandler) -> Attribute {
+pub fn on_wheel(handler: Handler) -> Attribute {
   event("wheel", handler)
 }
 

--- a/src/sprocket/internal/exceptions.gleam
+++ b/src/sprocket/internal/exceptions.gleam
@@ -1,30 +1,27 @@
-import gleam/io
 import sprocket/internal/logger
 
 pub fn throw_on_unexpected_deps_mismatch(meta: any) {
-  logger.error(
+  logger.error_meta(
     "
     An unexpected change in hook dependencies was encountered. This means that the list of hook
     dependencies dynamically changed after the initial render. This is not supported and will 
     result in undefined behavior.
     ",
+    meta,
   )
-
-  io.debug(meta)
 
   // TODO: we probably want to try and handle this more gracefully in production configurations
   panic
 }
 
 pub fn throw_on_unexpected_hook_result(meta: any) {
-  logger.error(
+  logger.error_meta(
     "
     An unexpected hook result was encountered. This means that a hook was dynamically added
     after the initial render. This is not supported and will result in undefined behavior.
     ",
+    meta,
   )
-
-  io.debug(meta)
 
   // TODO: we probably want to try and handle this more gracefully in production configurations
   panic

--- a/src/sprocket/internal/logger.gleam
+++ b/src/sprocket/internal/logger.gleam
@@ -1,4 +1,5 @@
 import gleam/dynamic.{type Dynamic}
+import gleam/io
 
 pub type Level {
   Emergency
@@ -25,18 +26,41 @@ pub fn log(level: Level, message: String) -> Nil {
   Nil
 }
 
+pub fn log_meta(level: Level, message: String, meta: a) -> a {
+  erlang_log(level, message)
+
+  // TODO: Do something interesting to capture metadata. For now, just log it.
+  io.debug(meta)
+}
+
 pub fn info(message: String) -> Nil {
   log(Info, message)
+}
+
+pub fn info_meta(message: String, meta: a) -> a {
+  log_meta(Info, message, meta)
 }
 
 pub fn warn(message: String) -> Nil {
   log(Warning, message)
 }
 
+pub fn warn_meta(message: String, meta: a) -> a {
+  log_meta(Warning, message, meta)
+}
+
 pub fn error(message: String) -> Nil {
   log(Error, message)
 }
 
+pub fn error_meta(message: String, meta: a) -> a {
+  log_meta(Error, message, meta)
+}
+
 pub fn debug(message: String) -> Nil {
   log(Debug, message)
+}
+
+pub fn debug_meta(message: String, meta: a) -> a {
+  log_meta(Debug, message, meta)
 }

--- a/src/sprocket/internal/reconcile.gleam
+++ b/src/sprocket/internal/reconcile.gleam
@@ -2,17 +2,19 @@ import gleam/dynamic.{type Dynamic}
 import gleam/option.{type Option}
 import sprocket/context.{
   type AbstractFunctionalComponent, type ComponentHooks, type Context,
-  type Element, Context,
+  type Element, type ElementId, Context,
 }
+import sprocket/internal/utils/unique.{type Unique}
 
 pub type ReconciledAttribute {
   ReconciledAttribute(name: String, value: String)
-  ReconciledEventHandler(kind: String, id: String)
+  ReconciledEventHandler(element_id: Unique(ElementId), kind: String)
   ReconciledClientHook(name: String, id: String)
 }
 
 pub type ReconciledElement {
   ReconciledElement(
+    id: Unique(ElementId),
     tag: String,
     key: Option(String),
     attrs: List(ReconciledAttribute),

--- a/src/sprocket/renderers/html.gleam
+++ b/src/sprocket/renderers/html.gleam
@@ -4,12 +4,14 @@ import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/string
 import gleam/string_tree.{type StringTree}
+import sprocket/context.{type ElementId}
 import sprocket/internal/constants
 import sprocket/internal/reconcile.{
   type ReconciledAttribute, type ReconciledElement, ReconciledAttribute,
   ReconciledComponent, ReconciledCustom, ReconciledElement, ReconciledFragment,
   ReconciledIgnoreUpdate, ReconciledText,
 }
+import sprocket/internal/utils/unique.{type Unique}
 import sprocket/render.{type Renderer, Renderer}
 
 pub fn html_renderer() -> Renderer(String) {
@@ -21,8 +23,13 @@ pub fn html_renderer() -> Renderer(String) {
 
 fn render(el: ReconciledElement) -> StringTree {
   case el {
-    ReconciledElement(tag: tag, key: key, attrs: attrs, children: children) ->
-      element(tag, key, attrs, children)
+    ReconciledElement(
+      id: id,
+      tag: tag,
+      key: key,
+      attrs: attrs,
+      children: children,
+    ) -> element(id, tag, key, attrs, children)
     ReconciledComponent(el: el, ..) -> component(el)
     ReconciledFragment(children: children, ..) -> fragment(children)
     ReconciledIgnoreUpdate(el) -> render(el)
@@ -45,6 +52,7 @@ fn el(tag: String, attrs: StringTree, inner_html: StringTree) -> StringTree {
 }
 
 fn element(
+  _id: Unique(ElementId),
   tag: String,
   key: Option(String),
   attrs: List(ReconciledAttribute),

--- a/test/sprocket/hooks/state_test.gleam
+++ b/test/sprocket/hooks/state_test.gleam
@@ -2,7 +2,7 @@ import gleam/int
 import gleam/string
 import sprocket/component.{component}
 import sprocket/context.{type Context}
-import sprocket/hooks.{handler, state}
+import sprocket/hooks.{state}
 import sprocket/html/attributes.{id}
 import sprocket/html/elements.{button, fragment, text}
 import sprocket/html/events.{on_click}
@@ -17,8 +17,8 @@ fn inc_reset_on_button_click_using_state(ctx: Context, _props) {
   use ctx, count, set_count <- state(ctx, 0)
 
   // Define event handlers
-  use ctx, on_increment <- handler(ctx, fn(_) { set_count(count + 1) })
-  use ctx, on_reset <- handler(ctx, fn(_) { set_count(0) })
+  let increment = fn(_) { set_count(count + 1) }
+  let reset = fn(_) { set_count(0) }
 
   let current_count = int.to_string(count)
 
@@ -27,8 +27,8 @@ fn inc_reset_on_button_click_using_state(ctx: Context, _props) {
     fragment([
       text("current count is: "),
       text(current_count),
-      button([id("increment"), on_click(on_increment)], [text("increment")]),
-      button([id("reset"), on_click(on_reset)], [text("reset")]),
+      button([id("increment"), on_click(increment)], [text("increment")]),
+      button([id("reset"), on_click(reset)], [text("reset")]),
     ]),
   )
 }

--- a/test/sprocket/hooks_test.gleam
+++ b/test/sprocket/hooks_test.gleam
@@ -5,7 +5,7 @@ import gleam/string
 import gleeunit/should
 import sprocket/component.{component}
 import sprocket/context.{type Context, dep}
-import sprocket/hooks.{type Cmd, effect, handler, reducer, state}
+import sprocket/hooks.{type Cmd, effect, reducer, state}
 import sprocket/html/attributes.{id}
 import sprocket/html/elements.{button, fragment, text}
 import sprocket/html/events.{on_click}
@@ -168,8 +168,8 @@ fn inc_reset_on_button_click_counter(ctx: Context, _props) {
   )
 
   // Define event handlers
-  use ctx, increment <- handler(ctx, fn(_) { set_count(count + 1) })
-  use ctx, reset <- handler(ctx, fn(_) { set_count(0) })
+  let increment = fn(_) { set_count(count + 1) }
+  let reset = fn(_) { set_count(0) }
 
   let current_count = int.to_string(count)
 
@@ -240,9 +240,9 @@ fn inc_random_reset_counter(ctx: Context, _props) {
   use ctx, Model(count: count), dispatch <- reducer(ctx, initial(), update)
 
   // Define event handlers
-  use ctx, increment <- handler(ctx, fn(_) { dispatch(SetCount(count + 1)) })
-  use ctx, generate_random <- handler(ctx, fn(_) { dispatch(GenerateRandom) })
-  use ctx, reset <- handler(ctx, fn(_) { dispatch(ResetCount) })
+  let increment = fn(_) { dispatch(SetCount(count + 1)) }
+  let generate_random = fn(_) { dispatch(GenerateRandom) }
+  let reset = fn(_) { dispatch(ResetCount) }
 
   let current_count = int.to_string(count)
 
@@ -323,7 +323,7 @@ fn count_down(ctx: Context, _props) {
   )
 
   // Define event handlers
-  use ctx, start <- handler(ctx, fn(_) { dispatch(CountDown(count)) })
+  let start = fn(_) { dispatch(CountDown(count)) }
 
   let current_count = int.to_string(count)
 
@@ -368,7 +368,7 @@ fn component_with_initial_cmds(ctx: Context, _props) {
   )
 
   // Define event handlers
-  use ctx, reset <- handler(ctx, fn(_) { dispatch(ResetCount) })
+  let reset = fn(_) { dispatch(ResetCount) }
 
   let current_count = int.to_string(count)
 

--- a/test/sprocket/patch_test.gleam.bak
+++ b/test/sprocket/patch_test.gleam.bak
@@ -11,6 +11,7 @@ import sprocket/internal/reconcile.{
   ReconciledAttribute, ReconciledComponent, ReconciledElement, ReconciledText,
 }
 import sprocket/internal/utils/ordered_map
+import sprocket/internal/utils/unique
 
 const empty_element = Element(tag: "div", attrs: [], children: [])
 
@@ -25,14 +26,28 @@ pub fn text_change_test() {
       key: None,
       props: props,
       hooks: ordered_map.new(),
-      el: ReconciledElement(tag: "div", key: None, attrs: [], children: [
-        ReconciledElement(tag: "p", key: None, attrs: [], children: [
-          ReconciledText("Hello"),
-        ]),
-        ReconciledElement(tag: "p", key: None, attrs: [], children: [
-          ReconciledText("World"),
-        ]),
-      ]),
+      el: ReconciledElement(
+        id: unique.from_string("a"),
+        tag: "div",
+        key: None,
+        attrs: [],
+        children: [
+          ReconciledElement(
+            id: unique.from_string("b"),
+            tag: "p",
+            key: None,
+            attrs: [],
+            children: [ReconciledText("Hello")],
+          ),
+          ReconciledElement(
+            id: unique.from_string("c"),
+            tag: "p",
+            key: None,
+            attrs: [],
+            children: [ReconciledText("World")],
+          ),
+        ],
+      ),
     )
 
   let second =
@@ -41,14 +56,28 @@ pub fn text_change_test() {
       key: None,
       props: props,
       hooks: ordered_map.new(),
-      el: ReconciledElement(tag: "div", key: None, attrs: [], children: [
-        ReconciledElement(tag: "p", key: None, attrs: [], children: [
-          ReconciledText("Hello"),
-        ]),
-        ReconciledElement(tag: "p", key: None, attrs: [], children: [
-          ReconciledText("Changed"),
-        ]),
-      ]),
+      el: ReconciledElement(
+        id: unique.from_string("d"),
+        tag: "div",
+        key: None,
+        attrs: [],
+        children: [
+          ReconciledElement(
+            id: unique.from_string("e"),
+            tag: "p",
+            key: None,
+            attrs: [],
+            children: [ReconciledText("Hello")],
+          ),
+          ReconciledElement(
+            id: unique.from_string("f"),
+            tag: "p",
+            key: None,
+            attrs: [],
+            children: [ReconciledText("Changed")],
+          ),
+        ],
+      ),
     )
 
   patch.create(first, second)
@@ -84,7 +113,13 @@ pub fn first_fc_without_children_test() {
       key: None,
       props: props,
       hooks: ordered_map.new(),
-      el: ReconciledElement(tag: "div", key: None, attrs: [], children: []),
+      el: ReconciledElement(
+        id: unique.from_string("a"),
+        tag: "div",
+        key: None,
+        attrs: [],
+        children: [],
+      ),
     )
 
   let second =
@@ -93,14 +128,28 @@ pub fn first_fc_without_children_test() {
       key: None,
       props: props,
       hooks: ordered_map.new(),
-      el: ReconciledElement(tag: "div", key: None, attrs: [], children: [
-        ReconciledElement(tag: "p", key: None, attrs: [], children: [
-          ReconciledText("Hello"),
-        ]),
-        ReconciledElement(tag: "p", key: None, attrs: [], children: [
-          ReconciledText("Changed"),
-        ]),
-      ]),
+      el: ReconciledElement(
+        id: unique.from_string("b"),
+        tag: "div",
+        key: None,
+        attrs: [],
+        children: [
+          ReconciledElement(
+            id: unique.from_string("c"),
+            tag: "p",
+            key: None,
+            attrs: [],
+            children: [ReconciledText("Hello")],
+          ),
+          ReconciledElement(
+            id: unique.from_string("d"),
+            tag: "p",
+            key: None,
+            attrs: [],
+            children: [ReconciledText("Changed")],
+          ),
+        ],
+      ),
     )
 
   patch.create(first, second)
@@ -115,13 +164,17 @@ pub fn first_fc_without_children_test() {
             #(
               0,
               Insert(
-                ReconciledElement("p", None, [], [ReconciledText("Hello")]),
+                ReconciledElement(unique.from_string("c"), "p", None, [], [
+                  ReconciledText("Hello"),
+                ]),
               ),
             ),
             #(
               1,
               Insert(
-                ReconciledElement("p", None, [], [ReconciledText("Changed")]),
+                ReconciledElement(unique.from_string("d"), "p", None, [], [
+                  ReconciledText("Changed"),
+                ]),
               ),
             ),
           ]),
@@ -141,14 +194,28 @@ pub fn add_child_test() {
       key: None,
       props: props,
       hooks: ordered_map.new(),
-      el: ReconciledElement(tag: "div", key: None, attrs: [], children: [
-        ReconciledElement(tag: "p", key: None, attrs: [], children: [
-          ReconciledText("Hello"),
-        ]),
-        ReconciledElement(tag: "p", key: None, attrs: [], children: [
-          ReconciledText("World"),
-        ]),
-      ]),
+      el: ReconciledElement(
+        id: unique.from_string("a"),
+        tag: "div",
+        key: None,
+        attrs: [],
+        children: [
+          ReconciledElement(
+            id: unique.from_string("b"),
+            tag: "p",
+            key: None,
+            attrs: [],
+            children: [ReconciledText("Hello")],
+          ),
+          ReconciledElement(
+            id: unique.from_string("c"),
+            tag: "p",
+            key: None,
+            attrs: [],
+            children: [ReconciledText("World")],
+          ),
+        ],
+      ),
     )
 
   let second =
@@ -157,20 +224,42 @@ pub fn add_child_test() {
       key: None,
       props: props,
       hooks: ordered_map.new(),
-      el: ReconciledElement(tag: "div", key: None, attrs: [], children: [
-        ReconciledElement(tag: "p", key: None, attrs: [], children: [
-          ReconciledText("Hello"),
-        ]),
-        ReconciledElement(tag: "p", key: None, attrs: [], children: [
-          ReconciledText("Great"),
-        ]),
-        ReconciledElement(tag: "p", key: None, attrs: [], children: [
-          ReconciledText("Big"),
-        ]),
-        ReconciledElement(tag: "p", key: None, attrs: [], children: [
-          ReconciledText("World"),
-        ]),
-      ]),
+      el: ReconciledElement(
+        id: unique.from_string("d"),
+        tag: "div",
+        key: None,
+        attrs: [],
+        children: [
+          ReconciledElement(
+            id: unique.from_string("e"),
+            tag: "p",
+            key: None,
+            attrs: [],
+            children: [ReconciledText("Hello")],
+          ),
+          ReconciledElement(
+            id: unique.from_string("f"),
+            tag: "p",
+            key: None,
+            attrs: [],
+            children: [ReconciledText("Great")],
+          ),
+          ReconciledElement(
+            id: unique.from_string("g"),
+            tag: "p",
+            key: None,
+            attrs: [],
+            children: [ReconciledText("Big")],
+          ),
+          ReconciledElement(
+            id: unique.from_string("h"),
+            tag: "p",
+            key: None,
+            attrs: [],
+            children: [ReconciledText("World")],
+          ),
+        ],
+      ),
     )
 
   patch.create(first, second)
@@ -186,17 +275,25 @@ pub fn add_child_test() {
             #(
               2,
               Insert(
-                ReconciledElement(tag: "p", key: None, attrs: [], children: [
-                  ReconciledText("Big"),
-                ]),
+                ReconciledElement(
+                  id: unique.from_string("g"),
+                  tag: "p",
+                  key: None,
+                  attrs: [],
+                  children: [ReconciledText("Big")],
+                ),
               ),
             ),
             #(
               3,
               Insert(
-                ReconciledElement(tag: "p", key: None, attrs: [], children: [
-                  ReconciledText("World"),
-                ]),
+                ReconciledElement(
+                  id: unique.from_string("h"),
+                  tag: "p",
+                  key: None,
+                  attrs: [],
+                  children: [ReconciledText("World")],
+                ),
               ),
             ),
           ]),
@@ -216,14 +313,28 @@ pub fn add_move_child_with_keys_test() {
       key: None,
       props: props,
       hooks: ordered_map.new(),
-      el: ReconciledElement(tag: "div", key: None, attrs: [], children: [
-        ReconciledElement(tag: "p", key: Some("hello"), attrs: [], children: [
-          ReconciledText("Hello"),
-        ]),
-        ReconciledElement(tag: "p", key: Some("world"), attrs: [], children: [
-          ReconciledText("World"),
-        ]),
-      ]),
+      el: ReconciledElement(
+        id: unique.from_string("a"),
+        tag: "div",
+        key: None,
+        attrs: [],
+        children: [
+          ReconciledElement(
+            id: unique.from_string("b"),
+            tag: "p",
+            key: Some("hello"),
+            attrs: [],
+            children: [ReconciledText("Hello")],
+          ),
+          ReconciledElement(
+            id: unique.from_string("c"),
+            tag: "p",
+            key: Some("world"),
+            attrs: [],
+            children: [ReconciledText("World")],
+          ),
+        ],
+      ),
     )
 
   let second =
@@ -232,20 +343,42 @@ pub fn add_move_child_with_keys_test() {
       key: None,
       props: props,
       hooks: ordered_map.new(),
-      el: ReconciledElement(tag: "div", key: None, attrs: [], children: [
-        ReconciledElement(tag: "p", key: Some("hello"), attrs: [], children: [
-          ReconciledText("Hello"),
-        ]),
-        ReconciledElement(tag: "p", key: Some("great"), attrs: [], children: [
-          ReconciledText("Great"),
-        ]),
-        ReconciledElement(tag: "p", key: Some("big"), attrs: [], children: [
-          ReconciledText("Big"),
-        ]),
-        ReconciledElement(tag: "p", key: Some("world"), attrs: [], children: [
-          ReconciledText("World"),
-        ]),
-      ]),
+      el: ReconciledElement(
+        id: unique.from_string("d"),
+        tag: "div",
+        key: None,
+        attrs: [],
+        children: [
+          ReconciledElement(
+            id: unique.from_string("e"),
+            tag: "p",
+            key: Some("hello"),
+            attrs: [],
+            children: [ReconciledText("Hello")],
+          ),
+          ReconciledElement(
+            id: unique.from_string("f"),
+            tag: "p",
+            key: Some("great"),
+            attrs: [],
+            children: [ReconciledText("Great")],
+          ),
+          ReconciledElement(
+            id: unique.from_string("g"),
+            tag: "p",
+            key: Some("big"),
+            attrs: [],
+            children: [ReconciledText("Big")],
+          ),
+          ReconciledElement(
+            id: unique.from_string("h"),
+            tag: "p",
+            key: Some("world"),
+            attrs: [],
+            children: [ReconciledText("World")],
+          ),
+        ],
+      ),
     )
 
   patch.create(first, second)
@@ -261,6 +394,7 @@ pub fn add_move_child_with_keys_test() {
               1,
               Replace(
                 ReconciledElement(
+                  id: unique.from_string("f"),
                   tag: "p",
                   key: Some("great"),
                   attrs: [],
@@ -272,6 +406,7 @@ pub fn add_move_child_with_keys_test() {
               2,
               Insert(
                 ReconciledElement(
+                  id: unique.from_string("g"),
                   tag: "p",
                   key: Some("big"),
                   attrs: [],
@@ -297,17 +432,28 @@ pub fn add_move_update_child_with_keys_test() {
       key: None,
       props: props,
       hooks: ordered_map.new(),
-      el: ReconciledElement(tag: "div", key: None, attrs: [], children: [
-        ReconciledElement(tag: "p", key: Some("hello"), attrs: [], children: [
-          ReconciledText("Hello"),
-        ]),
-        ReconciledElement(
-          tag: "p",
-          key: Some("world"),
-          attrs: [ReconciledAttribute("class", "round")],
-          children: [ReconciledText("World")],
-        ),
-      ]),
+      el: ReconciledElement(
+        id: unique.from_string("a"),
+        tag: "div",
+        key: None,
+        attrs: [],
+        children: [
+          ReconciledElement(
+            id: unique.from_string("b"),
+            tag: "p",
+            key: Some("hello"),
+            attrs: [],
+            children: [ReconciledText("Hello")],
+          ),
+          ReconciledElement(
+            id: unique.from_string("c"),
+            tag: "p",
+            key: Some("world"),
+            attrs: [ReconciledAttribute("class", "round")],
+            children: [ReconciledText("World")],
+          ),
+        ],
+      ),
     )
 
   let second =
@@ -316,26 +462,45 @@ pub fn add_move_update_child_with_keys_test() {
       key: None,
       props: props,
       hooks: ordered_map.new(),
-      el: ReconciledElement(tag: "div", key: None, attrs: [], children: [
-        ReconciledElement(tag: "p", key: Some("hello"), attrs: [], children: [
-          ReconciledText("Hello"),
-        ]),
-        ReconciledElement(tag: "p", key: Some("great"), attrs: [], children: [
-          ReconciledText("Great"),
-        ]),
-        ReconciledElement(tag: "p", key: Some("big"), attrs: [], children: [
-          ReconciledText("Big"),
-        ]),
-        ReconciledElement(
-          tag: "p",
-          key: Some("world"),
-          attrs: [
-            ReconciledAttribute("class", "round"),
-            ReconciledAttribute("class", "blue"),
-          ],
-          children: [ReconciledText("Blue"), ReconciledText("World")],
-        ),
-      ]),
+      el: ReconciledElement(
+        id: unique.from_string("d"),
+        tag: "div",
+        key: None,
+        attrs: [],
+        children: [
+          ReconciledElement(
+            id: unique.from_string("e"),
+            tag: "p",
+            key: Some("hello"),
+            attrs: [],
+            children: [ReconciledText("Hello")],
+          ),
+          ReconciledElement(
+            id: unique.from_string("f"),
+            tag: "p",
+            key: Some("great"),
+            attrs: [],
+            children: [ReconciledText("Great")],
+          ),
+          ReconciledElement(
+            id: unique.from_string("g"),
+            tag: "p",
+            key: Some("big"),
+            attrs: [],
+            children: [ReconciledText("Big")],
+          ),
+          ReconciledElement(
+            id: unique.from_string("h"),
+            tag: "p",
+            key: Some("world"),
+            attrs: [
+              ReconciledAttribute("class", "round"),
+              ReconciledAttribute("class", "blue"),
+            ],
+            children: [ReconciledText("Blue"), ReconciledText("World")],
+          ),
+        ],
+      ),
     )
 
   patch.create(first, second)
@@ -351,6 +516,7 @@ pub fn add_move_update_child_with_keys_test() {
               1,
               Replace(
                 ReconciledElement(
+                  id: unique.from_string("f"),
                   tag: "p",
                   key: Some("great"),
                   attrs: [],
@@ -362,6 +528,7 @@ pub fn add_move_update_child_with_keys_test() {
               2,
               Insert(
                 ReconciledElement(
+                  id: unique.from_string("g"),
                   tag: "p",
                   key: Some("big"),
                   attrs: [],

--- a/test/sprocket/reconcilers/recursive_test.gleam
+++ b/test/sprocket/reconcilers/recursive_test.gleam
@@ -4,7 +4,7 @@ import gleeunit/should
 import ids/cuid
 import sprocket/component.{component, render}
 import sprocket/context.{type Context, type Element, Attribute}
-import sprocket/hooks.{handler, provider}
+import sprocket/hooks.{provider}
 import sprocket/html/attributes.{class, classes}
 import sprocket/html/elements.{a, div, fragment, raw, text}
 import sprocket/html/events
@@ -40,7 +40,7 @@ type TestProps {
 fn test_component(ctx: Context, props: TestProps) {
   let TestProps(title: title, href: _href, is_active: is_active) = props
 
-  use ctx, handle_click <- handler(ctx, fn(_) { Nil })
+  let handle_click = fn(_) { Nil }
 
   render(
     ctx,
@@ -75,6 +75,7 @@ pub fn basic_render_test() {
     props,
     _hooks,
     ReconciledElement(
+      id: _,
       tag: "a",
       key: None,
       attrs: [
@@ -83,7 +84,7 @@ pub fn basic_render_test() {
           "block p-2 text-blue-500 hover:text-blue-700 font-bold",
         ),
         ReconciledAttribute("href", "#"),
-        ReconciledEventHandler("click", _),
+        ReconciledEventHandler(_, "click"),
       ],
       children: [ReconciledText("Home")],
     ),
@@ -96,8 +97,8 @@ pub fn basic_render_test() {
 }
 
 fn test_component_with_fragment(ctx: Context, _props: TestProps) {
-  use ctx, handle_click <- handler(ctx, fn(_) { Nil })
-  use ctx, handle_click_2 <- handler(ctx, fn(_) { Nil })
+  let handle_click = fn(_) { Nil }
+  let handle_click_2 = fn(_) { Nil }
 
   render(
     ctx,
@@ -138,6 +139,7 @@ pub fn render_with_fragment_test() {
       None,
       [
         ReconciledElement(
+          id: _,
           tag: "a",
           key: None,
           attrs: [
@@ -146,11 +148,12 @@ pub fn render_with_fragment_test() {
               "block p-2 text-blue-500 hover:text-blue-700",
             ),
             ReconciledAttribute("href", "#one"),
-            ReconciledEventHandler("click", _),
+            ReconciledEventHandler(_, "click"),
           ],
           children: [ReconciledText("One")],
         ),
         ReconciledElement(
+          id: _,
           tag: "a",
           key: None,
           attrs: [
@@ -159,7 +162,7 @@ pub fn render_with_fragment_test() {
               "block p-2 text-blue-500 hover:text-blue-700",
             ),
             ReconciledAttribute("href", "#two"),
-            ReconciledEventHandler("click", _),
+            ReconciledEventHandler(_, "click"),
           ],
           children: [ReconciledText("Two")],
         ),
@@ -186,7 +189,7 @@ fn test_component_with_context_title(ctx: Context, props: TestProps) {
     None -> "No title"
   }
 
-  use ctx, handle_click <- handler(ctx, fn(_) { Nil })
+  let handle_click = fn(_) { Nil }
 
   render(
     ctx,
@@ -225,11 +228,13 @@ pub fn renders_component_with_context_provider_test() {
     )
 
   let assert ReconciledElement(
+    id: _,
     tag: "div",
     key: None,
     attrs: [ReconciledAttribute("class", "first div")],
     children: [
       ReconciledElement(
+        id: _,
         tag: "div",
         key: None,
         attrs: [ReconciledAttribute("class", "second div")],
@@ -240,6 +245,7 @@ pub fn renders_component_with_context_provider_test() {
             _props,
             _hooks,
             ReconciledElement(
+              id: _,
               tag: "a",
               key: None,
               attrs: [
@@ -248,7 +254,7 @@ pub fn renders_component_with_context_provider_test() {
                   "block p-2 text-blue-500 hover:text-blue-700 font-bold",
                 ),
                 ReconciledAttribute("href", "#"),
-                ReconciledEventHandler("click", _),
+                ReconciledEventHandler(_, "click"),
               ],
               children: [ReconciledText("A different title")],
             ),


### PR DESCRIPTION
Removes the handler hook API and replaces it with a more transparent and simpler (at least, from the developer API perspective) element_id-based tracking system. The intent here is to keep the optimization where event ids remain stable across updates even though event handler callback functions may be recreated and re-bound on every render cycle, preventing unnecessary id changes in patches for event handlers.

This work achieves that by adding a stable `element_id` to the `ReconciledElement` record and utilizing the existing reconciler diffing logic to determine if an element is the same element as the previous element or if it is a new element that needs a new `element_id`.

With this new approach, it is no longer necessary for a developer to use hooks to define event handlers and event handling should be much simpler. For example, previously a component would need to be written as such:
```gleam
fn button_component(ctx: Context, _props) {
  use ctx, count, set_count <- state(ctx, 0)

  // Define event handlers
  use ctx, increment <- handler(ctx, fn(_) { set_count(count + 1) })
  use ctx, reset <- handler(ctx, fn(_) { set_count(0) })

  let current_count = int.to_string(count)

  component.render(
    ctx,
    fragment([
      text("current count is: " <> current_count),
      button([id("increment"), events.on_click(increment)], [
        text("increment"),
      ]),
      button([id("reset"), events.on_click(reset)], [text("reset")]),
    ]),
  )
}
```

Now with these changes, the component handlers can simply be written as normal functions:
```gleam
fn button_component(ctx: Context, _props) {
  use ctx, count, set_count <- state(ctx, 0)

  // Define event handlers
  let increment = fn(_) { set_count(count + 1) }
  let reset = fn(_) { set_count(0) }

  let current_count = int.to_string(count)

  component.render(
    ctx,
    fragment([
      text("current count is: " <> current_count),
      button([id("increment"), events.on_click(increment)], [text("increment")]),
      button([id("reset"), events.on_click(reset)], [text("reset")]),
    ]),
  )
}
```

Or with the handler callback inlined with the markup for simple cases:
```gleam
fn button_component(ctx: Context, _props) {
  use ctx, count, set_count <- state(ctx, 0)

  let current_count = int.to_string(count)

  component.render(
    ctx,
    fragment([
      text("current count is: " <> current_count),
      button(
        [id("increment"), events.on_click(fn(_) { set_count(count + 1) })],
        [text("increment")],
      ),
      button([id("reset"), events.on_click(fn(_) { set_count(0) })], [
        text("reset"),
      ]),
    ]),
  )
}
```